### PR TITLE
feat: Provide a base class for reading configuration settings from the Module Twin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+**/.env
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -45,7 +45,9 @@ stages:
                 $versionSuffix = ""
 
                 if( true -eq ${{parameters.PackagePreview}}) {
+                    Write-Host "set version suffix"
                     $versionSuffix = "-preview.$(Rev:rr)"
+                    Write-Host "version suffix is $versionSuffix"
                 }
 
                 Write-Host "##vso[task.setvariable variable=PackageVersion]${{parameters.PackageMajorVersion}}.${{parameters.PackageMinorVersion}}.${{parameters.PackagePatchVersion}}$versionSuffix"

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -55,6 +55,10 @@ stages:
           vmImage: 'ubuntu-latest'  
         steps:
           
+        - task: NuGetToolInstaller@1
+          inputs:
+            versionSpec: '>=4.30'
+
           - task: DotNetCoreCLI@2
             displayName: Package nuget Package
             inputs:

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -24,7 +24,24 @@ stages:
       - job: Compile_and_test
         pool:
           vmImage: 'ubuntu-latest'
-        steps:          
+        steps:
+        - task: Powershell@2
+          displayName: 'Set version environment variable'
+          inputs:
+            targetType: inline
+            script: |
+              $versionSuffix = ""
+
+              Write-Host "parameter: ${{parameters.PackagePreview}}"
+
+              if( $true -eq $${{parameters.PackagePreview}}) {
+                  Write-Host "set version suffix"
+                  $versionSuffix = "-preview.$(Rev:rr)"
+                  Write-Host "version suffix is $versionSuffix"
+              }
+
+              Write-Host "##vso[task.setvariable variable=PackageVersion]${{parameters.PackageMajorVersion}}.${{parameters.PackageMinorVersion}}.${{parameters.PackagePatchVersion}}$versionSuffix"
+
           - task: DotNetCoreCLI@2
             displayName: 'Build Fg.IoTEdgeModule solution'
             inputs:
@@ -37,22 +54,7 @@ stages:
         pool:
           vmImage: 'ubuntu-latest'  
         steps:
-          - task: Powershell@2
-            displayName: 'Set version environment variable'
-            inputs:
-              targetType: inline
-              script: |
-                $versionSuffix = ""
-
-                Write-Host "parameter: ${{parameters.PackagePreview}}"
-
-                if( $true -eq $${{parameters.PackagePreview}}) {
-                    Write-Host "set version suffix"
-                    $versionSuffix = "-preview.$(Rev:rr)"
-                    Write-Host "version suffix is $versionSuffix"
-                }
-
-                Write-Host "##vso[task.setvariable variable=PackageVersion]${{parameters.PackageMajorVersion}}.${{parameters.PackageMinorVersion}}.${{parameters.PackagePatchVersion}}$versionSuffix"
+          
           - task: DotNetCoreCLI@2
             displayName: Package nuget Package
             inputs:

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -42,11 +42,11 @@ stages:
 
               Write-Host "##vso[task.setvariable variable=PackageVersion]${{parameters.PackageMajorVersion}}.${{parameters.PackageMinorVersion}}.${{parameters.PackagePatchVersion}}$versionSuffix"
 
-          - task: DotNetCoreCLI@2
-            displayName: 'Build Fg.IoTEdgeModule solution'
-            inputs:
-              projects: 'src/Fg.IoTEdgeModule.sln'    
-              arguments: --configuration $(Build.Configuration) 
+        - task: DotNetCoreCLI@2
+          displayName: 'Build Fg.IoTEdgeModule solution'
+          inputs:
+            projects: 'src/Fg.IoTEdgeModule.sln'    
+            arguments: --configuration $(Build.Configuration) 
 
   - stage: Release
     jobs:

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -49,12 +49,10 @@ stages:
             script: |
               $versionSuffix = ""
 
-              Write-Host "parameter: ${{parameters.PackagePreview}}"
-
+              # Double $ before the parameter expression to make sure that the return type is
+              # treated as a boolean.
               if( $true -eq $${{parameters.PackagePreview}}) {
-                  Write-Host "set version suffix"
                   $versionSuffix = "-beta-$(Build.BuildNumber)"
-                  Write-Host "version suffix is $versionSuffix"
               }
 
               Write-Host "##vso[task.setvariable variable=PackageVersion]${{parameters.PackageMajorVersion}}.${{parameters.PackageMinorVersion}}.${{parameters.PackagePatchVersion}}$versionSuffix"

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -1,4 +1,4 @@
-name: $(date:yyyyMMdd)$(rev:.rr)
+name: $(date:yyyyMMdd)$(rev:_rr)
 
 trigger: none
 pr: none

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -55,9 +55,9 @@ stages:
           vmImage: 'ubuntu-latest'  
         steps:
           
-        - task: NuGetToolInstaller@1
-          inputs:
-            versionSpec: '>=4.30'
+          - task: NuGetToolInstaller@1
+            inputs:
+              versionSpec: '>=4.30'
 
           - task: DotNetCoreCLI@2
             displayName: Package nuget Package

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -46,7 +46,7 @@ stages:
 
                 Write-Host "parameter: ${{parameters.PackagePreview}}"
 
-                if( true -eq ${{parameters.PackagePreview}}) {
+                if( $true -eq ${{parameters.PackagePreview}}) {
                     Write-Host "set version suffix"
                     $versionSuffix = "-preview.$(Rev:rr)"
                     Write-Host "version suffix is $versionSuffix"

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -46,7 +46,7 @@ stages:
 
                 Write-Host "parameter: ${{parameters.PackagePreview}}"
 
-                if( $true -eq ${{parameters.PackagePreview}}) {
+                if( True -eq ${{parameters.PackagePreview}}) {
                     Write-Host "set version suffix"
                     $versionSuffix = "-preview.$(Rev:rr)"
                     Write-Host "version suffix is $versionSuffix"

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -44,6 +44,8 @@ stages:
               script: |
                 $versionSuffix = ""
 
+                Write-Host "parameter: ${{parameters.PackagePreview}}"
+
                 if( true -eq ${{parameters.PackagePreview}}) {
                     Write-Host "set version suffix"
                     $versionSuffix = "-preview.$(Rev:rr)"

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -1,4 +1,4 @@
-name: $(date:yyyyMMdd)$(rev:_rr)
+name: $(date:yyyyMMdd)$(rev:-rr)
 
 trigger: none
 pr: none

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -25,6 +25,23 @@ stages:
         pool:
           vmImage: 'ubuntu-latest'
         steps:
+        - task: DotNetCoreCLI@2
+          displayName: 'Build Fg.IoTEdgeModule solution'
+          inputs:
+            projects: 'src/Fg.IoTEdgeModule.sln'
+            arguments: --configuration $(Build.Configuration) 
+
+  - stage: Release
+    jobs:
+      - job: Package_and_push
+        pool:
+          vmImage: 'ubuntu-latest'  
+        steps:
+          
+        - task: NuGetToolInstaller@1
+          inputs:
+            versionSpec: '>=4.30'
+
         - task: Powershell@2
           displayName: 'Set version environment variable'
           inputs:
@@ -43,43 +60,28 @@ stages:
               Write-Host "##vso[task.setvariable variable=PackageVersion]${{parameters.PackageMajorVersion}}.${{parameters.PackageMinorVersion}}.${{parameters.PackagePatchVersion}}$versionSuffix"
 
         - task: DotNetCoreCLI@2
-          displayName: 'Build Fg.IoTEdgeModule solution'
+          displayName: Package nuget Package
           inputs:
-            projects: 'src/Fg.IoTEdgeModule.sln'
-            arguments: --configuration $(Build.Configuration) 
+            command: 'pack'
+            includesymbols: false
+            includesource: false
+            versioningScheme: byEnvVar
+            versionEnvVar: PackageVersion
+            projects: 'src/Fg.IoTEdgeModule/Fg.IoTEdgeModule.csproj'
+            arguments: --configuration $(Build.Configuration)
+            buildProperties: 'VersionPrefix=$(PackageVersion)'
+            outputDir: $(Build.StagingDirectory)/nupkg
 
-  - stage: Release
-    jobs:
-      - job: Package_and_push
-        pool:
-          vmImage: 'ubuntu-latest'  
-        steps:
-          
-          - task: NuGetToolInstaller@1
-            inputs:
-              versionSpec: '>=4.30'
+        - task: PublishPipelineArtifact@1
+          displayName: 'Publish Artifact'
+          inputs:
+            targetPath: '$(Build.StagingDirectory)'
+            artifact: 'artifact'
 
-          - task: DotNetCoreCLI@2
-            displayName: Package nuget Package
-            inputs:
-              command: 'pack'
-              includesymbols: false
-              includesource: false
-              versioningScheme: byEnvVar
-              versionEnvVar: PackageVersion
-              projects: 'src/Fg.IoTEdgeModule/Fg.IoTEdgeModule.csproj'
-              arguments: --configuration $(Build.Configuration)
-              buildProperties: 'VersionPrefix=$(PackageVersion)'
-              outputDir: $(Build.StagingDirectory)/nupkg
-          - task: PublishPipelineArtifact@1
-            displayName: 'Publish Artifact'
-            inputs:
-              targetPath: '$(Build.StagingDirectory)'
-              artifact: 'artifact'
-          - task: NuGetCommand@2
-            displayName: 'Push to NuGet.org'
-            inputs:
-              command: push
-              packagesToPush: '$(Build.StagingDirectory)/nupkg/*.nupkg'
-              nuGetFeedType: external
-              publishFeedCredentials: 'nuget-push'
+        - task: NuGetCommand@2
+          displayName: 'Push to NuGet.org'
+          inputs:
+            command: push
+            packagesToPush: '$(Build.StagingDirectory)/nupkg/*.nupkg'
+            nuGetFeedType: external
+            publishFeedCredentials: 'nuget-push'

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -1,4 +1,4 @@
-name: $(date:yyyyMMdd)$(rev:.r)
+name: $(date:yyyyMMdd)$(rev:.rr)
 
 trigger: none
 pr: none
@@ -36,7 +36,7 @@ stages:
 
               if( $true -eq $${{parameters.PackagePreview}}) {
                   Write-Host "set version suffix"
-                  $versionSuffix = "-preview.$(Rev:rr)"
+                  $versionSuffix = "-preview.$(Build.BuildNumber)"
                   Write-Host "version suffix is $versionSuffix"
               }
 
@@ -45,7 +45,7 @@ stages:
         - task: DotNetCoreCLI@2
           displayName: 'Build Fg.IoTEdgeModule solution'
           inputs:
-            projects: 'src/Fg.IoTEdgeModule.sln'    
+            projects: 'src/Fg.IoTEdgeModule.sln'
             arguments: --configuration $(Build.Configuration) 
 
   - stage: Release

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -36,7 +36,7 @@ stages:
 
               if( $true -eq $${{parameters.PackagePreview}}) {
                   Write-Host "set version suffix"
-                  $versionSuffix = "-preview-$(Build.BuildNumber)"
+                  $versionSuffix = "-beta-$(Build.BuildNumber)"
                   Write-Host "version suffix is $versionSuffix"
               }
 

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -36,7 +36,7 @@ stages:
 
               if( $true -eq $${{parameters.PackagePreview}}) {
                   Write-Host "set version suffix"
-                  $versionSuffix = "-preview.$(Build.BuildNumber)"
+                  $versionSuffix = "-preview-$(Build.BuildNumber)"
                   Write-Host "version suffix is $versionSuffix"
               }
 

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -10,6 +10,8 @@ parameters:
   type: number
 - name: PackagePatchVersion
   type: number
+- name: PackagePreview
+  type: boolean  
 
 
 variables:
@@ -40,7 +42,13 @@ stages:
             inputs:
               targetType: inline
               script: |
-                Write-Host "##vso[task.setvariable variable=PackageVersion]${{parameters.PackageMajorVersion}}.${{parameters.PackageMinorVersion}}.${{parameters.PackagePatchVersion}}"           
+                $versionSuffix = ""
+
+                if( true -eq ${{parameters.PackagePreview}}) {
+                    $versionSuffix = "-preview.$(Rev:rr)"
+                }
+
+                Write-Host "##vso[task.setvariable variable=PackageVersion]${{parameters.PackageMajorVersion}}.${{parameters.PackageMinorVersion}}.${{parameters.PackagePatchVersion}}$versionSuffix"
           - task: DotNetCoreCLI@2
             displayName: Package nuget Package
             inputs:

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -46,7 +46,7 @@ stages:
 
                 Write-Host "parameter: ${{parameters.PackagePreview}}"
 
-                if( True -eq ${{parameters.PackagePreview}}) {
+                if( $true -eq $${{parameters.PackagePreview}}) {
                     Write-Host "set version suffix"
                     $versionSuffix = "-preview.$(Rev:rr)"
                     Write-Host "version suffix is $versionSuffix"

--- a/readme.md
+++ b/readme.md
@@ -165,7 +165,7 @@ public class MyModuleConfiguration : ModuleConfiguration
 Usage:
 
 ```csharp
-var configuration = ModuleConfiguration.CreateFromTwinAsync<MyModuleConfiguration>(moduleClient, logger);
+var configuration = await ModuleConfiguration.CreateFromTwinAsync<MyModuleConfiguration>(moduleClient, logger);
 
 // Use the settings that originate from the ModuleTwin in some other classes.
 var processor = new MyProcessor(configuration.SomeIntegerProperty);

--- a/readme.md
+++ b/readme.md
@@ -134,3 +134,41 @@ using( var host = CreateHostBuilder().Build())
 ```
 
 Note that in the above code snippet we do not use `RunAsync`, but explicitly call `StartAsync` and `WaitForShutdownAsync`.  This is a [workaround](https://github.com/dotnet/runtime/issues/44086#issuecomment-811126003) for [this](https://github.com/dotnet/runtime/issues/44086) issue.
+
+### ModuleConfiguration
+
+This library contains an abstract `ModuleConfiguration` class that allows you to abstract configuration-settings for an IoT Edge module.
+The `ModuleConfiguration` class allows you to easily retrieve the desired properties from the module-twin and update the reported properties to the module twin as well.
+
+To use this functionality, you need to inherit from this base-class and implement some basic functionality:
+
+```csharp
+public class MyModuleConfiguration : ModuleConfiguration
+{
+    public int SomeIntegerProperty {get; private set;}
+    public string SomeStringProperty {get; private set;}
+
+    protected override void InitializeFromTwin(TwinCollection desiredProperties)
+    {
+        SomeIntegerProperty = Convert.ToInt32(desiredProperties["SomeIntegerConfigSetting"]);
+        SomeStringProperty = Convert.ToString(desiredProperties["SomeStringConfigSetting"]);
+    }
+
+    protected override void SetReportedProperties(TwinCollection reportedProperties)
+    {
+        reportedProperties["SomeIntegerConfigSetting"] = SomeIntegerProperty;
+        reportedProperties["SomeStringConfigSetting"] = SomeStringProperty;
+    }
+}
+```
+
+Usage:
+
+```csharp
+var configuration = ModuleConfiguration.CreateFromTwinAsync<MyModuleConfiguration>(moduleClient, logger);
+
+// Use the settings that originate from the ModuleTwin in some other classes.
+var processor = new MyProcessor(configuration.SomeIntegerProperty);
+```
+
+

--- a/src/Fg.IoTEdgeModule.Tests/EnvironmentFixture.cs
+++ b/src/Fg.IoTEdgeModule.Tests/EnvironmentFixture.cs
@@ -1,0 +1,32 @@
+﻿namespace Fg.IoTEdgeModule.Tests
+{
+    public class EnvironmentFixture
+    {
+        public EnvironmentFixture()
+        {
+            string envFilePath = Path.Combine(Directory.GetCurrentDirectory(), ".env");
+            LoadEnvironmentVariables(envFilePath);
+        }
+
+        private void LoadEnvironmentVariables(string environmentFile)
+        {
+            if (!File.Exists(environmentFile))
+            {
+                return;
+            }
+
+            var environmentVars = File.ReadAllLines(environmentFile);
+
+            foreach (var variable in environmentVars)
+            {
+                var parts = variable.Split('=', count: 2, StringSplitOptions.RemoveEmptyEntries);
+
+                if (parts.Length == 2)
+                {
+                    Environment.SetEnvironmentVariable(parts[0], parts[1]);
+                }
+            }
+
+        }
+    }
+}

--- a/src/Fg.IoTEdgeModule.Tests/Fg.IoTEdgeModule.Tests.csproj
+++ b/src/Fg.IoTEdgeModule.Tests/Fg.IoTEdgeModule.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Fg.IoTEdgeModule\Fg.IoTEdgeModule.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update=".env">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/src/Fg.IoTEdgeModule.Tests/ModuleConfigurationTests.cs
+++ b/src/Fg.IoTEdgeModule.Tests/ModuleConfigurationTests.cs
@@ -1,0 +1,43 @@
+using System.Security.Cryptography.X509Certificates;
+using Fg.IoTEdgeModule.Configuration;
+using Microsoft.Azure.Devices.Client;
+using Microsoft.Azure.Devices.Shared;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Fg.IoTEdgeModule.Tests
+{
+    public class ModuleConfigurationTests : IClassFixture<EnvironmentFixture>
+    {
+        public ModuleConfigurationTests(EnvironmentFixture environmentFixture)
+        {
+                
+        }
+
+        [Fact]
+        public void CanCreateConfiguration()
+        {
+            var moduleClient = ModuleClient.CreateFromConnectionString(Environment.GetEnvironmentVariable("EDGEMODULE_CONNECTIONSTRING"));
+
+            var config
+                = ModuleConfiguration.CreateFromTwinAsync<TestModuleConfiguration>(moduleClient, NullLogger.Instance);
+
+            Assert.NotNull(config);
+        }
+
+        private class TestModuleConfiguration : ModuleConfiguration
+        {
+           public TestModuleConfiguration(ILogger logger):base(logger){}
+            protected override string ModuleName => "TestModule";
+            protected override void InitializeFromTwin(TwinCollection desiredProperties)
+            {
+                int x = desiredProperties.Count;
+            }
+
+            protected override void SetReportedProperties(TwinCollection reportedProperties)
+            {
+             
+            }
+        }
+    }
+}

--- a/src/Fg.IoTEdgeModule.Tests/Usings.cs
+++ b/src/Fg.IoTEdgeModule.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/Fg.IoTEdgeModule.sln
+++ b/src/Fg.IoTEdgeModule.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30011.22
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32922.545
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fg.IoTEdgeModule", "Fg.IoTEdgeModule\Fg.IoTEdgeModule.csproj", "{736928CB-E477-4F38-AEA6-1A6E84A0B8E9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fg.IoTEdgeModule", "Fg.IoTEdgeModule\Fg.IoTEdgeModule.csproj", "{736928CB-E477-4F38-AEA6-1A6E84A0B8E9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fg.IoTEdgeModule.Tests", "Fg.IoTEdgeModule.Tests\Fg.IoTEdgeModule.Tests.csproj", "{E4432CBB-4AFC-48B8-B5AA-C2F7B81C2814}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{736928CB-E477-4F38-AEA6-1A6E84A0B8E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{736928CB-E477-4F38-AEA6-1A6E84A0B8E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{736928CB-E477-4F38-AEA6-1A6E84A0B8E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4432CBB-4AFC-48B8-B5AA-C2F7B81C2814}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4432CBB-4AFC-48B8-B5AA-C2F7B81C2814}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4432CBB-4AFC-48B8-B5AA-C2F7B81C2814}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4432CBB-4AFC-48B8-B5AA-C2F7B81C2814}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Fg.IoTEdgeModule/Configuration/ModuleConfiguration.cs
+++ b/src/Fg.IoTEdgeModule/Configuration/ModuleConfiguration.cs
@@ -18,6 +18,10 @@ namespace Fg.IoTEdgeModule.Configuration
 
         protected abstract string ModuleName { get; }
 
+        /// <summary>
+        /// Instantiate a <paramref name="TModuleConfiguration"/> instance and populate the configuration properties
+        /// with values that are defined in the Module Twin.
+        /// </summary>
         public static async Task<TModuleConfiguration> CreateFromTwinAsync<TModuleConfiguration>(ModuleClient moduleClient, ILogger logger) where TModuleConfiguration : ModuleConfiguration
         {
             var config =
@@ -58,6 +62,10 @@ namespace Fg.IoTEdgeModule.Configuration
             }
         }
 
+        /// <summary>
+        /// Get the Module's specific Configuration settings from the desiredProperties TwinCollection of the module Twin.
+        /// </summary>
+        /// <param name="desiredProperties">The TwinCollection that contains the desired properties from the Module Twin.</param>
         protected abstract void InitializeFromTwin(TwinCollection desiredProperties);
 
         /// <summary>

--- a/src/Fg.IoTEdgeModule/Configuration/ModuleConfiguration.cs
+++ b/src/Fg.IoTEdgeModule/Configuration/ModuleConfiguration.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.Azure.Devices.Client;
+using Microsoft.Azure.Devices.Shared;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fg.IoTEdgeModule.Configuration
+{
+    public abstract class ModuleConfiguration
+    {
+        protected ILogger<ModuleConfiguration> Logger;
+
+        protected ModuleConfiguration(ILogger<ModuleConfiguration> logger)
+        {
+            Logger = logger;
+        }
+
+        protected abstract string ModuleName { get; }
+
+        // TODO: find a way to 'force' inheritors to create / override a factory method for this type.
+        //       The factory method should read values from the Module Twin, and set them in the configuration.
+
+        /// <summary>
+        /// Reports the configuration settings via the Module Twin reported properties.
+        /// </summary>
+        /// <param name="moduleClient">The ModuleClient that must be used to communicate.</param>
+        /// <returns></returns>
+        public async Task UpdateReportedPropertiesAsync(ModuleClient moduleClient)
+        {
+            var reportedProperties = new TwinCollection();
+
+            SetReportedProperties(reportedProperties);
+
+            try
+            {
+                await moduleClient.UpdateReportedPropertiesAsync(reportedProperties);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"An error occured while trying to update the Module Twin's reported properties: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Set the Module's specific Configuration settings in the Module Twin.
+        /// </summary>
+        /// <param name="reportedProperties">The TwinCollection that must be used to set the reported properties.</param>
+        protected abstract void SetReportedProperties(TwinCollection reportedProperties);        
+    }
+}

--- a/src/Fg.IoTEdgeModule/Configuration/ModuleConfiguration.cs
+++ b/src/Fg.IoTEdgeModule/Configuration/ModuleConfiguration.cs
@@ -20,10 +20,13 @@ namespace Fg.IoTEdgeModule.Configuration
 
         public static async Task<TModuleConfiguration> CreateFromTwinAsync<TModuleConfiguration>(ModuleClient moduleClient, ILogger logger) where TModuleConfiguration : ModuleConfiguration
         {
-            var config = 
-                (TModuleConfiguration)Activator.CreateInstance(typeof(TModuleConfiguration),
-                                                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, 
-                                                        null, new object[] { logger }, null);
+            var config =
+                (TModuleConfiguration)Activator.CreateInstance(
+                    typeof(TModuleConfiguration),
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                    null, 
+                    new object[] { logger }, 
+                    null);
 
             var moduleTwin = await moduleClient.GetTwinAsync();
 

--- a/src/Fg.IoTEdgeModule/Configuration/ModuleConfiguration.cs
+++ b/src/Fg.IoTEdgeModule/Configuration/ModuleConfiguration.cs
@@ -2,8 +2,6 @@
 using Microsoft.Azure.Devices.Shared;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Fg.IoTEdgeModule.Configuration
@@ -21,7 +19,7 @@ namespace Fg.IoTEdgeModule.Configuration
 
         // TODO: find a way to 'force' inheritors to create / override a factory method for this type.
         //       The factory method should read values from the Module Twin, and set them in the configuration.
-
+        
         /// <summary>
         /// Reports the configuration settings via the Module Twin reported properties.
         /// </summary>
@@ -47,6 +45,6 @@ namespace Fg.IoTEdgeModule.Configuration
         /// Set the Module's specific Configuration settings in the Module Twin.
         /// </summary>
         /// <param name="reportedProperties">The TwinCollection that must be used to set the reported properties.</param>
-        protected abstract void SetReportedProperties(TwinCollection reportedProperties);        
+        protected abstract void SetReportedProperties(TwinCollection reportedProperties);
     }
 }

--- a/src/Fg.IoTEdgeModule/Configuration/ModuleConfiguration.cs
+++ b/src/Fg.IoTEdgeModule/Configuration/ModuleConfiguration.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 
 namespace Fg.IoTEdgeModule.Configuration
 {
+    /// <summary>
+    /// Base class for representing an IoT Edge Module's configuration.
+    /// </summary>
     public abstract class ModuleConfiguration
     {
         protected ILogger Logger;

--- a/src/Fg.IoTEdgeModule/Fg.IoTEdgeModule.csproj
+++ b/src/Fg.IoTEdgeModule/Fg.IoTEdgeModule.csproj
@@ -10,6 +10,7 @@
     <RepositoryType>Git</RepositoryType>
     <Description>Provides utilities to easily create Azure IoT Edge modules as a hosted service</Description>
     <PackageTags>Azure IoT Edge Host HostBuilder</PackageTags>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The ModuleConfiguration class acts as a base class for creating a 'configuration' class that is specific for a IoT Edge Module.
It allows for easy reading desired properties from the module twin and pushing back reported properties to the  module twin.