### PR TITLE
Add ModuleConfiguration factory method to easier test ModuleConfiguration implementations

### DIFF
--- a/src/Fg.IoTEdgeModule.Tests/Fg.IoTEdgeModule.Tests.csproj
+++ b/src/Fg.IoTEdgeModule.Tests/Fg.IoTEdgeModule.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
+      <LangVersion>Preview</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Fg.IoTEdgeModule.Tests/ModuleConfigurationTests.cs
+++ b/src/Fg.IoTEdgeModule.Tests/ModuleConfigurationTests.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography.X509Certificates;
 using Fg.IoTEdgeModule.Configuration;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.Shared;
@@ -11,7 +10,7 @@ namespace Fg.IoTEdgeModule.Tests
     {
         public ModuleConfigurationTests(EnvironmentFixture environmentFixture)
         {
-                
+
         }
 
         [Fact]
@@ -25,18 +24,35 @@ namespace Fg.IoTEdgeModule.Tests
             Assert.NotNull(config);
         }
 
+        [Fact]
+        public void CanInitializeConfiguration()
+        {
+            var desiredProperties = new TwinCollection("""{"SomeIntProperty":42, "SomeStringProperty": "stringvalue"}""");
+
+            var config = ModuleConfiguration.CreateFromTwin<TestModuleConfiguration>(desiredProperties, NullLogger.Instance);
+
+            Assert.Equal(42, config.SomeIntProperty);
+            Assert.Equal("stringvalue", config.SomeStringProperty);
+        }
+
         private class TestModuleConfiguration : ModuleConfiguration
         {
-           public TestModuleConfiguration(ILogger logger):base(logger){}
+            public TestModuleConfiguration(ILogger logger) : base(logger) { }
+
             protected override string ModuleName => "TestModule";
+           
+            public int SomeIntProperty { get; private set; }
+            public string SomeStringProperty { get; private set; }
+            
             protected override void InitializeFromTwin(TwinCollection desiredProperties)
             {
-                int x = desiredProperties.Count;
+                SomeIntProperty = desiredProperties["SomeIntProperty"];
+                SomeStringProperty = desiredProperties["SomeStringProperty"];
             }
 
             protected override void SetReportedProperties(TwinCollection reportedProperties)
             {
-             
+
             }
         }
     }

--- a/src/Fg.IoTEdgeModule/Configuration/ModuleConfiguration.cs
+++ b/src/Fg.IoTEdgeModule/Configuration/ModuleConfiguration.cs
@@ -45,6 +45,26 @@ namespace Fg.IoTEdgeModule.Configuration
         }
 
         /// <summary>
+        /// Instantiate a <paramref name="TModuleConfiguration"/> instance and populate the configuration properties
+        /// with values that are present in the <paramref name="desiredProperties"/> twin-collection.
+        /// </summary>
+        /// <remarks>Use this method for testing your <see cref="ModuleConfiguration"/> implementation.</remarks>
+        public static TModuleConfiguration CreateFromTwin<TModuleConfiguration>(TwinCollection desiredProperties, ILogger logger) where TModuleConfiguration : ModuleConfiguration
+        {
+            var config =
+                (TModuleConfiguration)Activator.CreateInstance(
+                    typeof(TModuleConfiguration),
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                    null,
+                    new object[] { logger },
+                    null);
+
+            config.InitializeFromTwin(desiredProperties);
+
+            return config;
+        }
+
+        /// <summary>
         /// Reports the configuration settings via the Module Twin reported properties.
         /// </summary>
         /// <param name="moduleClient">The ModuleClient that must be used to communicate.</param>


### PR DESCRIPTION
The new factory method allows you to create a ModuleConfiguration instance from a TwinCollection.  It removes the dependency of the ModuleClient which cannot be mocked / stubbed anyway.